### PR TITLE
feat: updated input-echo-source-file to use the SPECIAL_SOURCE_FILE e…

### DIFF
--- a/src/input_echo_test.py
+++ b/src/input_echo_test.py
@@ -118,6 +118,9 @@ def get_env_test():
 
     source_file = os.environ.get("SPECIAL_SOURCE_FILE")
     if source_file:
+        if "source_file" in properties:
+            # TEST_SOURCE_FILE conflicts with SPECIAL_SOURCE_FILE; keep special value
+            properties["test_source_file"] = properties["source_file"]
         properties["source_file"] = source_file
 
     return {


### PR DESCRIPTION
…nvironment variable to communicate the original config files associated with each test in the final report. This parameter is not considered a TEST_ input variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now capture optional environment-provided source-file metadata and include it in test properties for improved diagnostics. If a prior source-file value exists, it is preserved and the environment-provided value is recorded alongside it to avoid overwriting. This enhances traceability of test artifacts without changing public test interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->