### PR TITLE
fix: parameter hyphenation for check-http-availability and check-http…

### DIFF
--- a/resource-availability/docker-compose.yml
+++ b/resource-availability/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       - TEST_URL=https://brugge-ldes.geomobility.eu/observations
       - TEST_MAX-REDIRECTS=3
       - TEST_TIMEOUT=10
-      - TEST_CHECK_HTTP_AVAILABILITY=TRUE
-      - TEST_CHECK_HTTPS_AVAILABILITY=TRUE
+      - TEST_CHECK-HTTP-AVAILABILITY=TRUE
+      - TEST_CHECK-HTTPS-AVAILABILITY=TRUE
       - TEST_VERIFY-SSL=TRUE
     working_dir: /app
     networks:

--- a/resource-availability/src/resource_availability.py
+++ b/resource-availability/src/resource_availability.py
@@ -40,8 +40,8 @@ def parse_config():
         "urls": urls,
         "max_redirects": int(os.environ.get("TEST_MAX-REDIRECTS", "0")),
         "timeout": int(os.environ.get("TEST_TIMEOUT", "30")),
-        "check_http": os.environ.get("TEST_CHECK_HTTP_AVAILABILITY", "false").lower() == "true",
-        "check_https": os.environ.get("TEST_CHECK_HTTPS_AVAILABILITY", "true").lower() == "true",
+        "check_http": os.environ.get("TEST_CHECK-HTTP-AVAILABILITY", "false").lower() == "true",
+        "check_https": os.environ.get("TEST_CHECK-HTTPS-AVAILABILITY", "true").lower() == "true",
         "verify_ssl": os.environ.get("TEST_VERIFY-SSL", "true").lower() == "true",
     }
 


### PR DESCRIPTION
…s-availability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized environment variable naming for resource availability checks by replacing underscores with hyphens. Users with existing configurations must update their environment variable names accordingly. Functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->