### PR TITLE
feat: added default lenient mode for access_control_allow_origin + sk…

### DIFF
--- a/cors-compliance/src/cors_compliance.py
+++ b/cors-compliance/src/cors_compliance.py
@@ -518,6 +518,14 @@ def run_https_redirect_test(url, probe_origin, expected_origin, timeout):
                 failure_text = (
                     f"'access-control-allow-origin' absent from final response at {response.url}"
                 )
+            elif expected_origin is None:
+                # Lenient mode: accept '*' or the probe origin, same as run_allow_origin_test
+                if actual_origin != "*" and actual_origin != probe_origin:
+                    failure_message = "access-control-allow-origin incorrect after redirect"
+                    failure_text = (
+                        f"Expected '*' or {probe_origin!r} but got {actual_origin!r} "
+                        f"at {response.url}"
+                    )
             elif expected_origin == "*" and actual_origin != "*":
                 failure_message = "access-control-allow-origin incorrect after redirect"
                 failure_text = f"Expected '*' but got {actual_origin!r} at {response.url}"

--- a/cors-compliance/tests/test_cors_compliance.py
+++ b/cors-compliance/tests/test_cors_compliance.py
@@ -503,6 +503,27 @@ class TestRunHttpsRedirectTest:
         assert result["error"] is not None
         assert result["failure_message"] is None
 
+    def test_lenient_passes_when_wildcard_returned_after_redirect(self):
+        resp = make_response(200, headers={"access-control-allow-origin": "*"}, url="https://example.com")
+        chain = [("http://example.com", "https://example.com", 301)]
+        with patch("cors_compliance._follow_to_final", return_value=(resp, chain, None)):
+            result = run_https_redirect_test("https://example.com", "https://vliz.be", None, 10)
+        assert result["failure_message"] is None
+
+    def test_lenient_passes_when_probe_origin_reflected_after_redirect(self):
+        resp = make_response(200, headers={"access-control-allow-origin": "https://vliz.be"}, url="https://example.com")
+        chain = [("http://example.com", "https://example.com", 301)]
+        with patch("cors_compliance._follow_to_final", return_value=(resp, chain, None)):
+            result = run_https_redirect_test("https://example.com", "https://vliz.be", None, 10)
+        assert result["failure_message"] is None
+
+    def test_lenient_fails_when_arbitrary_origin_returned_after_redirect(self):
+        resp = make_response(200, headers={"access-control-allow-origin": "https://malicious.com"}, url="https://example.com")
+        chain = [("http://example.com", "https://example.com", 301)]
+        with patch("cors_compliance._follow_to_final", return_value=(resp, chain, None)):
+            result = run_https_redirect_test("https://example.com", "https://vliz.be", None, 10)
+        assert result["failure_message"] is not None
+
 
 # ---------------------------------------------------------------------------
 # run_tests_for_url


### PR DESCRIPTION
…ips test if probe-origin is the same origin as the URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default origin handling is now lenient when origins aren't specified, allowing flexible acceptance of probe-origin or wildcard in responses.
  * Origin comparisons are more robust, preventing acceptance of mixed wildcard/specific configurations.

* **Tests**
  * Test suite updated to validate lenient-origin behavior, redirect handling, and adjusted origin-matching semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->