### PR TITLE
chore: use --build flag in local testing instructions

### DIFF
--- a/check-certificate/README.md
+++ b/check-certificate/README.md
@@ -19,7 +19,7 @@ The test produces a failure if the certificate has expired, and a failure if it 
 A `docker-compose.yml` is included in this directory for running the test locally without the orchestrator. It is intended as a working example — edit the environment variables to match your own URLs and threshold before running:
 
 ```bash
-docker-compose up
+docker-compose up --build
 ```
 
 The report will be written to `./reports/localtestrun_report.xml`.

--- a/content-negotiation/README.md
+++ b/content-negotiation/README.md
@@ -18,7 +18,7 @@ This test is primarily aimed at resources that serve RDF or linked data formats,
 A `docker-compose.yml` is included in this directory for running the test locally without the orchestrator. It is intended as a working example — edit the environment variables to match your own URLs and `Accept` headers before running:
 
 ```bash
-docker-compose up
+docker-compose up --build
 ```
 
 The report will be written to `./reports/localtestrun_report.xml`.

--- a/cors-compliance/README.md
+++ b/cors-compliance/README.md
@@ -18,7 +18,7 @@ SSL certificate validity is intentionally not verified — that is the responsib
 A `docker-compose.yml` is included in this directory for running the test locally without the orchestrator. It is intended as a working example — edit the environment variables to match your own URLs and expected headers before running:
 
 ```bash
-docker-compose up
+docker-compose up --build
 ```
 
 The report will be written to `./reports/localtestrun_report.xml`.

--- a/input-echo-test/README.md
+++ b/input-echo-test/README.md
@@ -16,7 +16,7 @@ Two test cases are produced:
 A `docker-compose.yml` is included in this directory for running the test locally without the orchestrator. The included example deliberately sets one empty variable (`TEST_EMPTY_VAR`) to demonstrate what a failure looks like:
 
 ```bash
-docker-compose up
+docker-compose up --build
 ```
 
 The report will be written to `./reports/localtestrun_report.xml`.

--- a/resource-availability/README.md
+++ b/resource-availability/README.md
@@ -19,7 +19,7 @@ If DNS resolution fails for a URL, the HTTP and HTTPS availability checks for th
 A `docker-compose.yml` is included in this directory for running the test locally without the orchestrator. It is intended as a working example — edit the environment variables to match your own URLs and settings before running:
 
 ```bash
-docker-compose up
+docker-compose up --build
 ```
 
 The report will be written to `./reports/localtestrun_report.xml`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local testing instructions across test modules to use `docker-compose up --build` instead of `docker-compose up`, ensuring Docker images are rebuilt when starting the test environment locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->